### PR TITLE
Update to v1.22

### DIFF
--- a/prepare-debugging.ps1
+++ b/prepare-debugging.ps1
@@ -1,4 +1,4 @@
-Remove-Item "bin/vsdebug" -Force -Recurse; 
-New-Item -Path "bin/vsdebug" -Name "vsvillage" -ItemType "directory"; 
-Copy-Item -Path "resources/*" -Destination "bin/vsdebug/vsvillage" -Recurse;
-Copy-Item -Path "bin/Debug/net7.0/*" -Destination "bin/vsdebug/vsvillage";
+Remove-Item "bin/vsdebug" -Force -Recurse;
+New-Item -Path "bin/vsdebug" -Name "wolftaming" -ItemType "directory";
+Copy-Item -Path "resources/*" -Destination "bin/vsdebug/wolftaming" -Recurse;
+Copy-Item -Path "bin/Debug/net10.0/*" -Destination "bin/vsdebug/wolftaming";

--- a/resources/assets/wolftaming/entities/land/dog-adult.json
+++ b/resources/assets/wolftaming/entities/land/dog-adult.json
@@ -761,7 +761,7 @@
                         "damagePlayerAtMs": 500,
                         "animation": "Attack",
                         "animationSpeed": 1.5,
-                        "sound": "game:creature/wolf/attack"
+                        "sound": "game:creature/wolf/attack*"
                     },
                     {
                         "code": "petmeleeattack",
@@ -795,7 +795,7 @@
                         "damagePlayerAtMs": 500,
                         "animation": "Attack-Low",
                         "animationSpeed": 1.5,
-                        "sound": "game:creature/wolf/attack"
+                        "sound": "game:creature/wolf/attack*"
                     },
                     {
                         "code": "petmeleeattack",
@@ -829,7 +829,7 @@
                         "damagePlayerAtMs": 900,
                         "animation": "attack-withwindup",
                         "animationSpeed": 1.5,
-                        "sound": "game:creature/wolf/attack"
+                        "sound": "game:creature/wolf/attack*"
                     },
                     {
                         "code": "petseekentity",

--- a/resources/assets/wolftaming/patches/entities/chicken/chicken-adult.json
+++ b/resources/assets/wolftaming/patches/entities/chicken/chicken-adult.json
@@ -1,5 +1,6 @@
 [
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/11/aitasks/0/entityCodes/-",
         "value": [
@@ -11,6 +12,7 @@
         "file": "game:entities/animal/bird/chicken-adult.json"
     },
     {
+        "side": "server",
         "op": "add",
         "path": "/server/behaviors/11/aitasks/-",
         "value": {

--- a/resources/assets/wolftaming/patches/entities/chicken/chicken-baby.json
+++ b/resources/assets/wolftaming/patches/entities/chicken/chicken-baby.json
@@ -1,5 +1,6 @@
 [
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/10/aitasks/0/entityCodes/-",
         "value": [
@@ -11,6 +12,7 @@
         "file": "game:entities/animal/bird/chicken-baby.json"
     },
     {
+        "side": "server",
         "op": "add",
         "path": "/server/behaviors/10/aitasks/-",
         "value": {

--- a/resources/assets/wolftaming/patches/entities/foxes/fox.json
+++ b/resources/assets/wolftaming/patches/entities/foxes/fox.json
@@ -1,5 +1,6 @@
 [
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/11/aitasks/3/entityCodes/-",
         "value": [
@@ -15,6 +16,7 @@
         "file": "game:entities/animal/mammal/fox-adult.json"
     },
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/11/aitasks/1/entityCodes/-",
         "value": [

--- a/resources/assets/wolftaming/patches/entities/hares/hare-adult.json
+++ b/resources/assets/wolftaming/patches/entities/hares/hare-adult.json
@@ -1,5 +1,6 @@
 [
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/11/aitasks/0/entityCodes/-",
         "value": [

--- a/resources/assets/wolftaming/patches/entities/hares/hare-baby.json
+++ b/resources/assets/wolftaming/patches/entities/hares/hare-baby.json
@@ -1,5 +1,6 @@
 [
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/9/aitasks/0/entityCodes/-",
         "value": [

--- a/resources/assets/wolftaming/patches/entities/hooved/deer.json
+++ b/resources/assets/wolftaming/patches/entities/hooved/deer.json
@@ -1,5 +1,6 @@
 [
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/10/aitasks/0/entityCodes/-",
         "value": [
@@ -15,6 +16,7 @@
         "file": "game:entities/animal/mammal/hooved/deer-adult.json"
     },
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/10/aitasks/1/entityCodes/-",
         "value": [
@@ -30,6 +32,7 @@
         "file": "game:entities/animal/mammal/hooved/deer-adult.json"
     },
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/10/aitasks/2/entityCodes/-",
         "value": [
@@ -45,6 +48,7 @@
         "file": "game:entities/animal/mammal/hooved/deer-adult.json"
     },
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/11/aitasks/0/entityCodes/-",
         "value": [

--- a/resources/assets/wolftaming/patches/entities/hooved/gazelle.json
+++ b/resources/assets/wolftaming/patches/entities/hooved/gazelle.json
@@ -1,5 +1,6 @@
 [
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/9/aitasks/0/entityCodes/-",
         "value": [
@@ -15,6 +16,7 @@
         "file": "game:entities/animal/mammal/hooved/gazelle-adult.json"
     },
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/10/aitasks/0/entityCodes/-",
         "value": [

--- a/resources/assets/wolftaming/patches/entities/hooved/goat.json
+++ b/resources/assets/wolftaming/patches/entities/hooved/goat.json
@@ -1,5 +1,6 @@
 [
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/12/aitasks/0/entityCodes/-",
         "value": [
@@ -11,6 +12,7 @@
         "file": "game:entities/animal/mammal/hooved/goat-adult.json"
     },
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/12/aitasks/1/entityCodes/-",
         "value": [
@@ -22,6 +24,7 @@
         "file": "game:entities/animal/mammal/hooved/goat-adult.json"
     },
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/12/aitasks/2/entityCodes/-",
         "value": [
@@ -33,6 +36,7 @@
         "file": "game:entities/animal/mammal/hooved/goat-adult.json"
     },
     {
+        "side": "server",
         "op": "add",
         "path": "/server/behaviors/12/aitasks/-",
         "value": {
@@ -52,6 +56,7 @@
         "file": "game:entities/animal/mammal/hooved/goat-adult.json"
     },
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/11/aitasks/0/entityCodes/-",
         "value": [
@@ -63,6 +68,7 @@
         "file": "game:entities/animal/mammal/hooved/goat-baby.json"
     },
     {
+        "side": "server",
         "op": "add",
         "path": "/server/behaviors/11/aitasks/-",
         "value": {

--- a/resources/assets/wolftaming/patches/entities/hooved/moose.json
+++ b/resources/assets/wolftaming/patches/entities/hooved/moose.json
@@ -1,5 +1,6 @@
 [
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/10/aitasks/0/entityCodes/-",
         "value": [
@@ -15,6 +16,7 @@
         "file": "game:entities/animal/mammal/hooved/moose-adult.json"
     },
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/10/aitasks/1/entityCodes/-",
         "value": [
@@ -30,6 +32,7 @@
         "file": "game:entities/animal/mammal/hooved/moose-adult.json"
     },
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/10/aitasks/2/entityCodes/-",
         "value": [
@@ -45,6 +48,7 @@
         "file": "game:entities/animal/mammal/hooved/moose-adult.json"
     },
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/11/aitasks/0/entityCodes/-",
         "value": [

--- a/resources/assets/wolftaming/patches/entities/hooved/moose.json
+++ b/resources/assets/wolftaming/patches/entities/hooved/moose.json
@@ -12,7 +12,7 @@
             "dog-corgi-male",
             "dog-corgi-female"
         ],
-        "file": "game:entities/animal/mammal/hooved/moose.json"
+        "file": "game:entities/animal/mammal/hooved/moose-adult.json"
     },
     {
         "op": "addeach",

--- a/resources/assets/wolftaming/patches/entities/hooved/pig.json
+++ b/resources/assets/wolftaming/patches/entities/hooved/pig.json
@@ -1,5 +1,6 @@
 [
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/10/aitasks/0/entityCodes/-",
         "value": [
@@ -11,6 +12,7 @@
         "file": "game:entities/animal/mammal/hooved/pig-adult.json"
     },
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/10/aitasks/1/entityCodes/-",
         "value": [
@@ -22,6 +24,7 @@
         "file": "game:entities/animal/mammal/hooved/pig-adult.json"
     },
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/10/aitasks/2/entityCodes/-",
         "value": [
@@ -33,6 +36,7 @@
         "file": "game:entities/animal/mammal/hooved/pig-adult.json"
     },
     {
+        "side": "server",
         "op": "add",
         "path": "/server/behaviors/10/aitasks/-",
         "value": {
@@ -47,6 +51,7 @@
         "file": "game:entities/animal/mammal/hooved/pig-adult.json"
     },
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/10/aitasks/0/entityCodes/-",
         "value": [
@@ -58,6 +63,7 @@
         "file": "game:entities/animal/mammal/hooved/pig-baby.json"
     },
     {
+        "side": "server",
         "op": "add",
         "path": "/server/behaviors/10/aitasks/-",
         "value": {

--- a/resources/assets/wolftaming/patches/entities/hooved/sheep.json
+++ b/resources/assets/wolftaming/patches/entities/hooved/sheep.json
@@ -1,5 +1,6 @@
 [
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/10/aitasks/0/entityCodes/-",
         "value": [
@@ -11,6 +12,7 @@
         "file": "game:entities/animal/mammal/hooved/sheep-adult.json"
     },
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/10/aitasks/1/entityCodes/-",
         "value": [
@@ -22,6 +24,7 @@
         "file": "game:entities/animal/mammal/hooved/sheep-adult.json"
     },
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/10/aitasks/2/entityCodes/-",
         "value": [
@@ -33,6 +36,7 @@
         "file": "game:entities/animal/mammal/hooved/sheep-adult.json"
     },
     {
+        "side": "server",
         "op": "add",
         "path": "/server/behaviors/10/aitasks/-",
         "value": {
@@ -47,6 +51,7 @@
         "file": "game:entities/animal/mammal/hooved/sheep-adult.json"
     },
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/10/aitasks/0/entityCodes/-",
         "value": [
@@ -58,6 +63,7 @@
         "file": "game:entities/animal/mammal/hooved/sheep-baby.json"
     },
     {
+        "side": "server",
         "op": "add",
         "path": "/server/behaviors/10/aitasks/-",
         "value": {

--- a/resources/assets/wolftaming/patches/entities/hyenas/hyena-adult.json
+++ b/resources/assets/wolftaming/patches/entities/hyenas/hyena-adult.json
@@ -1,5 +1,6 @@
 [
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/11/aitasks/0/entityCodes/-",
         "value": [
@@ -15,6 +16,7 @@
         "file": "game:entities/animal/mammal/hyena-adult.json"
     },
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/11/aitasks/1/entityCodes/-",
         "value": [
@@ -30,6 +32,7 @@
         "file": "game:entities/animal/mammal/hyena-adult.json"
     },
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/11/aitasks/3/entityCodes/-",
         "value": [

--- a/resources/assets/wolftaming/patches/entities/raccoons/raccoon-adult.json
+++ b/resources/assets/wolftaming/patches/entities/raccoons/raccoon-adult.json
@@ -1,5 +1,6 @@
 [
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/10/aitasks/0/entityCodes/-",
         "value": [
@@ -15,6 +16,7 @@
         "file": "game:entities/animal/mammal/raccoon-adult.json"
     },
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/10/aitasks/1/entityCodes/-",
         "value": [
@@ -30,6 +32,7 @@
         "file": "game:entities/animal/mammal/raccoon-adult.json"
     },
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/10/aitasks/2/entityCodes/-",
         "value": [

--- a/resources/assets/wolftaming/patches/entities/raccoons/raccoon-baby.json
+++ b/resources/assets/wolftaming/patches/entities/raccoons/raccoon-baby.json
@@ -1,5 +1,6 @@
 [
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/10/aitasks/0/entityCodes/-",
         "value": [

--- a/resources/assets/wolftaming/patches/entities/traders/trader-luxuries.json
+++ b/resources/assets/wolftaming/patches/entities/traders/trader-luxuries.json
@@ -1,5 +1,6 @@
 [
     {
+        "side": "server",
         "op": "add",
         "path": "/selling/list/-",
         "value": {

--- a/resources/assets/wolftaming/patches/entities/traders/trader-survivalgoods.json
+++ b/resources/assets/wolftaming/patches/entities/traders/trader-survivalgoods.json
@@ -1,5 +1,6 @@
 [
     {
+        "side": "server",
         "op": "addeach",
         "path": "/selling/list/-",
         "value": [

--- a/resources/assets/wolftaming/patches/entities/wolfes/wolf-adult.json
+++ b/resources/assets/wolftaming/patches/entities/wolfes/wolf-adult.json
@@ -1,5 +1,6 @@
 [
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/10/aitasks/0/entityCodes/-",
         "value": [
@@ -15,6 +16,7 @@
         "file": "game:entities/animal/mammal/wolf-adult.json"
     },
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/10/aitasks/1/entityCodes/-",
         "value": [
@@ -30,6 +32,7 @@
         "file": "game:entities/animal/mammal/wolf-adult.json"
     },
     {
+        "side": "server",
         "op": "addeach",
         "path": "/server/behaviors/10/aitasks/4/entityCodes/-",
         "value": [

--- a/resources/assets/wolftaming/patches/entities/wolfes/wolf-baby.json
+++ b/resources/assets/wolftaming/patches/entities/wolfes/wolf-baby.json
@@ -1,5 +1,6 @@
 [
     {
+        "side": "server",
         "op": "add",
         "path": "/server/behaviors/-",
         "value": {
@@ -31,6 +32,7 @@
         "file": "game:entities/animal/mammal/wolf-baby.json"
     },
     {
+        "side": "server",
         "op": "add",
         "path": "/server/behaviors/-",
         "value": {
@@ -57,6 +59,7 @@
         "file": "game:entities/animal/mammal/wolf-baby.json"
     },
     {
+        "side": "server",
         "op": "add",
         "path": "/client/behaviors/-",
         "value": {
@@ -87,6 +90,7 @@
         "file": "game:entities/animal/mammal/wolf-baby.json"
     },
     {
+        "side": "server",
         "op": "add",
         "path": "/client/behaviors/-",
         "value": {
@@ -113,6 +117,7 @@
         "file": "game:entities/animal/mammal/wolf-baby.json"
     },
     {
+        "side": "server",
         "op": "add",
         "path": "/server/behaviors/10/aitasks/-",
         "value": {

--- a/resources/assets/wolftaming/patches/shapes/wolf-pup.json
+++ b/resources/assets/wolftaming/patches/shapes/wolf-pup.json
@@ -66,7 +66,7 @@
 				}
 			]
 		},
-        "file": "game:shapes/entity/land/wolf-pup.json"
+        "file": "game:shapes/entity/animal/mammal/wolf/eurasian-baby.json"
     },
     {
         "op": "add",

--- a/resources/assets/wolftaming/recipes/smithing/dogarmor.json
+++ b/resources/assets/wolftaming/recipes/smithing/dogarmor.json
@@ -48,6 +48,7 @@
         ]
     ],
     "name": "Dog Armor",
+    "code": "dogarmor-{metal}",
     "output": {
         "type": "item",
         "code": "dogarmor-{metal}"

--- a/resources/assets/wolftaming/recipes/smithing/doghelmet.json
+++ b/resources/assets/wolftaming/recipes/smithing/doghelmet.json
@@ -30,6 +30,7 @@
         ]
     ],
     "name": "Dog Helmet",
+    "code": "doghelmet-{metal}",
     "output": {
         "type": "item",
         "code": "doghelmet-{metal}"

--- a/src/Entity/AITask/AiTaskPlayFetch.cs
+++ b/src/Entity/AITask/AiTaskPlayFetch.cs
@@ -24,7 +24,7 @@ namespace Wolftaming
         public override bool ShouldExecute()
         {
             if (dogToy == null || !dogToy.Alive || dogToy.ShouldDespawn) return false;
-            if (entity.ServerPos.SquareDistanceTo(dogToy.ServerPos) > 30 * 30)
+            if (entity.Pos.SquareDistanceTo(dogToy.Pos) > 30 * 30)
             {
                 dogToy = null;
             }
@@ -35,7 +35,7 @@ namespace Wolftaming
             base.StartExecute();
 
             float size = dogToy.CollisionBox.XSize;
-            pathTraverser.WalkTowards(dogToy.ServerPos.XYZ, moveSpeed, size + 0.2f, OnGoalReached, OnStuck);
+            pathTraverser.WalkTowards(dogToy.Pos.XYZ, moveSpeed, size + 0.2f, OnGoalReached, OnStuck);
 
             stuck = false;
         }
@@ -59,15 +59,15 @@ namespace Wolftaming
                 return false;
             }
 
-            double x = dogToy.ServerPos.X;
-            double y = dogToy.ServerPos.Y;
-            double z = dogToy.ServerPos.Z;
+            double x = dogToy.Pos.X;
+            double y = dogToy.Pos.Y;
+            double z = dogToy.Pos.Z;
 
             pathTraverser.CurrentTarget.X = x;
             pathTraverser.CurrentTarget.Y = y;
             pathTraverser.CurrentTarget.Z = z;
 
-            if (entity.ServerPos.SquareDistanceTo(x, y, z) < 2)
+            if (entity.Pos.SquareDistanceTo(x, y, z) < 2)
             {
                 var slot = new DummySlot(dogToy.Itemstack);
                 if (slot.TryPutInto(entity.World, entity.LeftHandItemSlot) > 0)
@@ -93,19 +93,19 @@ namespace Wolftaming
         {
             if (owner == null || !owner.Alive || owner.ShouldDespawn)
             {
-                owner = entity.World.GetNearestEntity(entity.ServerPos.XYZ, 50, 10, entity => entity is EntityPlayer);
+                owner = entity.World.GetNearestEntity(entity.Pos.XYZ, 50, 10, entity => entity is EntityPlayer);
                 if (owner == null) return false;
             }
 
-            double x = owner.ServerPos.X;
-            double y = owner.ServerPos.Y;
-            double z = owner.ServerPos.Z;
+            double x = owner.Pos.X;
+            double y = owner.Pos.Y;
+            double z = owner.Pos.Z;
 
             pathTraverser.CurrentTarget.X = x;
             pathTraverser.CurrentTarget.Y = y;
             pathTraverser.CurrentTarget.Z = z;
 
-            if (entity.ServerPos.SquareDistanceTo(x, y, z) < 2)
+            if (entity.Pos.SquareDistanceTo(x, y, z) < 2)
             {
                 pathTraverser.Stop();
                 owner = null;

--- a/src/Entity/AITask/AiTaskStayCloseToShepherd.cs
+++ b/src/Entity/AITask/AiTaskStayCloseToShepherd.cs
@@ -18,7 +18,7 @@ namespace Wolftaming
             if (lastCheck + 20000 < entity.Api.World.ElapsedMilliseconds && entity.WatchedAttributes.GetInt("generation", 0) > 0)
             {
                 lastCheck = entity.World.ElapsedMilliseconds;
-                var candidate = entity.World.GetNearestEntity(entity.ServerPos.XYZ, range, 2, e => e?.Properties?.Attributes?["IsShepherd"].AsBool() == true);
+                var candidate = entity.World.GetNearestEntity(entity.Pos.XYZ, range, 2, e => e?.Properties?.Attributes?["IsShepherd"].AsBool() == true);
 
                 if (candidate != null)
                 {
@@ -27,11 +27,11 @@ namespace Wolftaming
             }
             if (targetEntity != null)
             {
-                double x = targetEntity.ServerPos.X;
-                double y = targetEntity.ServerPos.Y;
-                double z = targetEntity.ServerPos.Z;
+                double x = targetEntity.Pos.X;
+                double y = targetEntity.Pos.Y;
+                double z = targetEntity.Pos.Z;
 
-                double dist = entity.ServerPos.SquareDistanceTo(x, y, z);
+                double dist = entity.Pos.SquareDistanceTo(x, y, z);
 
                 if (dist > maxDistance * maxDistance * 4)
                 {

--- a/src/Item/ItemDogToy.cs
+++ b/src/Item/ItemDogToy.cs
@@ -80,11 +80,11 @@ namespace Wolftaming
             double rndpitch = byEntity.WatchedAttributes.GetDouble("aimingRandPitch", 1) * acc * 0.75;
             double rndyaw = byEntity.WatchedAttributes.GetDouble("aimingRandYaw", 1) * acc * 0.75;
 
-            Vec3d pos = byEntity.ServerPos.XYZ.Add(0, byEntity.LocalEyePos.Y - 0.2, 0);
+            Vec3d pos = byEntity.Pos.XYZ.Add(0, byEntity.LocalEyePos.Y - 0.2, 0);
 
-            Vec3d aheadPos = pos.AheadCopy(1, byEntity.ServerPos.Pitch + rndpitch, byEntity.ServerPos.Yaw + rndyaw);
+            Vec3d aheadPos = pos.AheadCopy(1, byEntity.Pos.Pitch + rndpitch, byEntity.Pos.Yaw + rndyaw);
             Vec3d velocity = (aheadPos - pos) * 0.65;
-            Vec3d spawnPos = byEntity.ServerPos.BehindCopy(0.21).XYZ.Add(byEntity.LocalEyePos.X, byEntity.LocalEyePos.Y - 0.2, byEntity.LocalEyePos.Z);
+            Vec3d spawnPos = byEntity.Pos.BehindCopy(0.21).XYZ.Add(byEntity.LocalEyePos.X, byEntity.LocalEyePos.Y - 0.2, byEntity.LocalEyePos.Z);
 
             byEntity.StartAnimation("throw");
             notifyDogs(byEntity.World.SpawnItemEntity(new ItemStack(this), spawnPos, velocity) as EntityItem);
@@ -96,7 +96,7 @@ namespace Wolftaming
 
         private void notifyDogs(EntityItem dogToy)
         {
-            var dogs = dogToy?.World?.GetEntitiesAround(dogToy.ServerPos.XYZ, 20f, 5f);
+            var dogs = dogToy?.World?.GetEntitiesAround(dogToy.Pos.XYZ, 20f, 5f);
             if (dogs == null) { return; }
             foreach (var dog in dogs)
             {

--- a/wolftaming.csproj
+++ b/wolftaming.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>Net8.0</TargetFramework>
+		<TargetFramework>Net10.0</TargetFramework>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Part 2 of "bring the pet suite mods to 1.22.0"; requires G3rste/petai#78.

- VS now uses .NET 10 instead of 8
- The prepare script needed new paths
- Batch-replaced `ServerPos` with `Pos` to avoid warnings during build
- Smithing recipes now warn if missing `code` field at the top. From looking into 1.22's very own assets, reusing the same code as in the output seems to be alright
- Seems some JSON patches are quite dated, and 1.22 now complains about outright invalid file paths.
  - Updated wolf-pup path in shape patch to match changes to wolves that happened in 1.19/1.20; pups now do the same happy dance as adults when see a treat
  - Updated moose path in first patch so they can attack and not just charge into dogs – seems it was forgotten when 6ac978c82a9a7ae4c1b2005d7eac3e428a0f71b7 happened
- 1.22 introduced multiple `attack1.ogg, attack2.ogg, ...` sounds for wolves, so the tame wolf attacks became silent; I updated the dog JSON to use same `attack*`
- Same as with core mod, I sprinkled the patches with `side:server` to get rid of `not found` messages in logs. Can be re-done in a separate PR for clarity.

(this is first time I worked with JSON patches in VS, so not really sure I did it right)